### PR TITLE
allow access to workspace tags and update unsupported str hash syntax

### DIFF
--- a/lib/togglv8/version.rb
+++ b/lib/togglv8/version.rb
@@ -1,4 +1,4 @@
 module TogglV8
   # :section:
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end

--- a/lib/togglv8/workspaces.rb
+++ b/lib/togglv8/workspaces.rb
@@ -36,6 +36,10 @@ module TogglV8
       get "workspaces/#{workspace_id}/tasks#{active}"
     end
 
+    def tags(workspace_id)
+      get "workspaces/#{workspace_id}/tags"
+    end
+
     def leave_workspace(workspace_id)
       delete "workspaces/#{workspace_id}/leave"
     end

--- a/spec/lib/togglv8/tags_spec.rb
+++ b/spec/lib/togglv8/tags_spec.rb
@@ -24,6 +24,13 @@ describe 'Tags' do
       expect(@tag['notes']).to eq nil
       expect(@tag['wid']).to eq @workspace_id
     end
+
+    it 'returns tag associated with workspace_id' do
+      tags = @toggl.tags(@workspace_id)
+      expect(tags).not_to be_empty
+      expect(tags.first['name']).to eq 'new tag +1'
+      expect(tags.first['wid']).to eq @workspace_id
+    end
   end
 
   context 'updated tag' do

--- a/spec/lib/togglv8/tasks_spec.rb
+++ b/spec/lib/togglv8/tasks_spec.rb
@@ -78,7 +78,7 @@ describe 'Tasks', :pro_account do
       expect(active_flags).to match_array([true, true, true])
 
       t_ids = [@task1, @task2, @task3].map { |t| t['id'] }
-      params = { 'active': false }
+      params = { 'active' => false }
       @toggl.update_tasks(t_ids, params)
 
       # end with no active tasks


### PR DESCRIPTION
Creating new get request that gives access to a workspace's tags. Also, cleaning up old hash syntax that was breaking tests.