### PR TITLE
update syntax in the "report" and "project" functions

### DIFF
--- a/lib/reportsv2.rb
+++ b/lib/reportsv2.rb
@@ -75,8 +75,8 @@ module TogglV8
     def report(type, extension, params)
       raise "workspace_id is required" if @workspace_id.nil?
       get "#{type}#{extension}", {
-        'user_agent': @user_agent,
-        'workspace_id': @workspace_id,
+        :'user_agent' => @user_agent,
+        :'workspace_id' => @workspace_id,
       }.merge(params)
     end
 
@@ -159,9 +159,9 @@ module TogglV8
     def project(project_id, params={})
       raise "workspace_id is required" if @workspace_id.nil?
       get "project", {
-        'user_agent': @user_agent,
-        'workspace_id': @workspace_id,
-        'project_id': project_id,
+        :'user_agent' => @user_agent,
+        :'workspace_id' => @workspace_id,
+        :'project_id' => project_id,
       }.merge(params)
     end
 


### PR DESCRIPTION
the hashes in the "report" and "project" functions were choking in ruby 1.9.3 so i changed them and they seem to work now. maybe it's no good for more recent versions of ruby, but 1.9.3 is what comes default with ubuntu