### PR TITLE
Accept API token file that ends with newline

### DIFF
--- a/lib/togglv8/togglv8.rb
+++ b/lib/togglv8/togglv8.rb
@@ -25,7 +25,7 @@ module TogglV8
         toggl_api_file = File.join(Dir.home, TOGGL_FILE)
         # logger.debug("toggl_api_file = #{toggl_api_file}")
         if File.exist?(toggl_api_file) then
-          username = IO.read(toggl_api_file)
+          username = IO.read(toggl_api_file).strip
         else
           raise "Expecting one of:\n" +
             " 1) api_token in file #{toggl_api_file}, or\n" +

--- a/spec/lib/togglv8_spec.rb
+++ b/spec/lib/togglv8_spec.rb
@@ -45,6 +45,17 @@ describe 'TogglV8' do
       expect(me['email']).to eq Testing::EMAIL
     end
 
+    it 'initializes with .toggl file ending with a newline' do
+      toggl_file = File.join(@tmp_home, '.toggl')
+      File.open(toggl_file, 'w') { |file| file.write(Testing::API_TOKEN + "\n") }
+
+      toggl = TogglV8::API.new
+      me = toggl.me
+      expect(me).to_not be nil
+      expect(me['api_token']).to eq Testing::API_TOKEN
+      expect(me['email']).to eq Testing::EMAIL
+    end
+
     it 'raises error if .toggl file is missing' do
       expect{ toggl = TogglV8::API.new }.to raise_error(RuntimeError)
     end


### PR DESCRIPTION
When API token file `~/.toggl` ends with a whitespace or a newline, the request to Toggl API looks like
```
1971800d4d82861d8f2c1651fea4d212
:api_token
```
and thus causes 403 Forbidden error.

The whitespace should removed when loading from file.