### PR TITLE
Rails 5 fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--order defined

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 rvm:
   - ruby-head
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - 2.1.10
-  - 2.0.0-p648
+  - 2.6.3
+  - 2.5.5
+  - 2.4.6
+  - 2.3.8
 script: bundle exec rspec --format documentation
 cache: bundler
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Version numbers are meant to adhere to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+* fix GET for non-json responses (modern Oj.load)
+* fix ordering issues in tests
 * remove unneeded dependencies and references (logger awesome-print pry-byebug)
 
 ## [1.2.1] - 2016-07-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version numbers are meant to adhere to [Semantic Versioning](http://semver.org/)
 
 ## [Unreleased]
 
+* remove unneeded dependencies and references (logger awesome-print pry-byebug)
 
 ## [1.2.1] - 2016-07-25
 ### Changed

--- a/lib/logging.rb
+++ b/lib/logging.rb
@@ -1,6 +1,5 @@
 # :nocov:
 require 'logger'
-# require 'awesome_print' # for debug output
 
 # From http://stackoverflow.com/questions/917566/ruby-share-logger-instance-among-module-classes
 module Logging

--- a/lib/togglv8/connection.rb
+++ b/lib/togglv8/connection.rb
@@ -42,7 +42,6 @@ module TogglV8
       loop do
         i += 1
         full_resp = procs[:api_call].call
-        # logger.ap(full_resp.env, :debug)
         break if full_resp.status != 429 || i >= MAX_RETRIES
         sleep(DELAY_SEC)
       end

--- a/spec/lib/togglv8/workspaces_spec.rb
+++ b/spec/lib/togglv8/workspaces_spec.rb
@@ -12,17 +12,17 @@ describe 'Workspaces' do
   end
 
   it 'shows users' do
-    users = @toggl.users(@workspace_id)
+    users = @toggl.users(@workspace_id).sort {|a,b| a['id'] <=> b['id']}
     expect(users.length).to eq 2
 
-    expect(users.first['id']).to       eq Testing::OTHER_USER_ID
-    expect(users.first['email']).to    eq Testing::OTHER_EMAIL
-    expect(users.first['fullname']).to eq Testing::OTHER_USERNAME
+    expect(users.first['id']).to       eq Testing::USER_ID
+    expect(users.first['email']).to    eq Testing::EMAIL
+    expect(users.first['fullname']).to eq Testing::USERNAME
+    expect(users.first['default_wid']).to eq @workspace_id
 
-    expect(users.last['id']).to          eq Testing::USER_ID
-    expect(users.last['email']).to       eq Testing::EMAIL
-    expect(users.last['fullname']).to    eq Testing::USERNAME
-    expect(users.last['default_wid']).to eq @workspace_id
+    expect(users.last['id']).to          eq Testing::OTHER_USER_ID
+    expect(users.last['email']).to       eq Testing::OTHER_EMAIL
+    expect(users.last['fullname']).to    eq Testing::OTHER_USERNAME
   end
 
   context 'tasks', :pro_account do

--- a/togglv8.gemspec
+++ b/togglv8.gemspec
@@ -25,9 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "fivemat"
   spec.add_development_dependency "coveralls"
-  # spec.add_development_dependency "awesome_print"
 
-  spec.add_dependency "logger"
   spec.add_dependency "faraday"
   spec.add_dependency "oj"
 end


### PR DESCRIPTION
Not necessarily specific to Rails 5, but togglv8's dependency on `logger` gem causes selenium to fail due to `Selenium::WebDriver.logger.level` not being an integer

addresses https://github.com/kanet77/togglv8/issues/25

also fixed specs to run with
- Oj 3.7.12
- current toggle time_entries api (which only sometimes returns 'guid')