### PR TITLE
fix endpoint deprecation and switch to `api.track.toggl.com`

### DIFF
--- a/lib/reportsv2.rb
+++ b/lib/reportsv2.rb
@@ -1,5 +1,5 @@
 module TogglV8
-  TOGGL_REPORTS_URL = 'https://toggl.com/reports/api/'
+  TOGGL_REPORTS_URL = 'https://api.track.toggl.com/reports/api/'
 
   class ReportsV2
     include TogglV8::Connection

--- a/lib/togglv8/togglv8.rb
+++ b/lib/togglv8/togglv8.rb
@@ -10,7 +10,7 @@ require_relative 'version'
 require_relative 'workspaces'
 
 module TogglV8
-  TOGGL_API_URL = 'https://www.toggl.com/api/'
+  TOGGL_API_URL = 'https://api.track.toggl.com/api/'
 
   class API
     include TogglV8::Connection
@@ -41,15 +41,3 @@ module TogglV8
     end
   end
 end
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
> Deprecation Notice. Toggl Track API wont be available in this domain after June 2021. Check https://github.com/toggl/toggl_api_docs.