### PR TITLE
Update to match Faraday’s new basic auth API

### DIFF
--- a/lib/togglv8/connection.rb
+++ b/lib/togglv8/connection.rb
@@ -21,7 +21,7 @@ module TogglV8
         faraday.response :logger, Logger.new('faraday.log') if opts[:log]
         faraday.adapter Faraday.default_adapter
         faraday.headers = { "Content-Type" => "application/json" }
-        faraday.basic_auth username, password
+        faraday.request :authorization, :basic, username, password
       end
     end
 


### PR DESCRIPTION
This commit fixes [issue 28](https://github.com/kanet77/togglv8/issues/28) by updating to the new Toggl API URL.